### PR TITLE
Rename R_I386_GOTPC to R_386_GOTPC

### DIFF
--- a/x86-64-ABI/object-files.tex
+++ b/x86-64-ABI/object-files.tex
@@ -511,7 +511,7 @@ to those used for the \intelabi.  \footnote{Even though
 
 \begin{sloppypar}
 The \texttt{R_X86_64_GOTPCREL} relocation has different semantics from the
-\texttt{R_X86_64_GOT32} or equivalent i386 \texttt{R_I386_GOTPC} relocation.
+\texttt{R_X86_64_GOT32} or equivalent i386 \texttt{R_386_GOTPC} relocation.
 In particular, because the \xARCH architecture has an addressing mode relative
 to the instruction pointer, it is possible to load an address from the GOT
 using a single instruction.  The calculation done by the


### PR DESCRIPTION
R_I386_GOTPC is a typo.  It should be R_386_GOTPC.

	* object-files.tex (Relocation Types): Rename R_I386_GOTPC to
	R_386_GOTPC.